### PR TITLE
Update aws_eip resource to set domain to "vpc"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Build and Push
 on:
   pull_request:
     branches: [ main, develop ]
+    paths:
+      - 'backend/**'
   workflow_dispatch:
 
 jobs:

--- a/IaC/modules/vpc/nat_gw.tf
+++ b/IaC/modules/vpc/nat_gw.tf
@@ -1,6 +1,6 @@
 # Create Elastic IP
 resource "aws_eip" "main" {
-  vpc = true
+  domain = "vpc"
 }
 
 # Create NAT Gateway

--- a/IaC/modules/vpc/nat_gw.tf
+++ b/IaC/modules/vpc/nat_gw.tf
@@ -3,6 +3,7 @@ resource "aws_eip" "main" {
   domain = "vpc"
 }
 
+
 # Create NAT Gateway
 resource "aws_nat_gateway" "main" {
   allocation_id = aws_eip.main.id
@@ -12,13 +13,6 @@ resource "aws_nat_gateway" "main" {
     Name = "NAT Gateway for Custom Kubernetes Cluster"
   }
 }
-
-## Add route to route table
-#resource "aws_route" "private" {
-#  route_table_id            = aws_vpc.custom_vpc.default_route_table_id
-#  destination_cidr_block    = "0.0.0.0/0"
-#  nat_gateway_id = aws_nat_gateway.main.id
-#}
 
 resource "aws_route_table" "private" {
   vpc_id = aws_vpc.custom_vpc.id

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/SOAT1StackGoLang/Hackaton
 
-go 1.21.6
+go 1.21
 
 require (
 	github.com/Boostport/migration v1.1.2


### PR DESCRIPTION
This pull request updates the aws_eip resource to set the domain to "vpc". This change ensures that the Elastic IP is created in the VPC domain.