### PR TITLE
Update .gitignore and Dockerfile, fix server initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ IaC/.terraform.lock.hcl
 # Project Files
 .env
 
+.vscode/launch.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,7 +30,7 @@ RUN swag init -g helpers.go -o ./docs/ -d ./internal/transport/routes -ot go
 RUN go build -o /go/bin/app -v cmd/server/*.go
 
 # Build the migrations
-RUN go build -o /go/bin/migrations -v cmd/migrations/*.go
+RUN go build -o /go/bin/migs -v cmd/migrations/*.go
 
 # final stage
 FROM alpine:latest

--- a/backend/cmd/server/init.go
+++ b/backend/cmd/server/init.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"flag"
+
 	"github.com/SOAT1StackGoLang/Hackaton/pkg/helpers"
 	logger "github.com/SOAT1StackGoLang/Hackaton/pkg/middleware"
-	"github.com/joho/godotenv"
 )
 
 // initializeApp initializes the application by loading the configuration, connecting to the datastore,
@@ -18,10 +18,10 @@ var (
 func initializeApp() {
 	flag.Parse()
 
-	err := godotenv.Load()
-	if err != nil {
-		logger.InfoLogger.Log("load err", err.Error())
-	}
+	// err := godotenv.Load()
+	// if err != nil {
+	// 	logger.InfoLogger.Log("load err", err.Error())
+	// }
 
 	helpers.ReadPgxConnEnvs()
 	connString = helpers.GetConnectionParams()

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - 8080:8080
     environment:
       # Database connection URI # check the initidb folder for more db information
-      DB_URI: postgres://postgres:postgres@services_db_1:5432/hackaton?sslmode=disable
+      DB_URI: postgres://postgres:postgres@backend_db_1:5432/hackaton?sslmode=disable
     # Specifies the services that this service depends on.
     depends_on:
       - db


### PR DESCRIPTION
This pull request includes updates to the .gitignore and Dockerfile, as well as fixes to the server initialization. The Dockerfile has been modified to build the migrations with the name "migs" instead of "migrations". Additionally, the server initialization code has been updated to remove the loading of the .env file.